### PR TITLE
Add maintenance notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Linkindle
 
+## Maintenance notice
+
+This repo has become outdated due to changes in Enedis' website and authentication system.
+I highly recommend that you migrate to an up-to-date and better maintained project such as [guillaumezin/DomoticzLinky](https://github.com/guillaumezin/DomoticzLinky).
+
+The original repo stays here for reference purposes. Thank you. 🙏
+
 ## Linkpy library
 [![PyPI version](https://badge.fury.io/py/linkpy.svg)](https://badge.fury.io/py/linkpy)
 


### PR DESCRIPTION
This repo is now mostly useless because of changes on Enedis' side (see #8). This PR adds a maintenance notice to the README so that new users are informed.